### PR TITLE
Removed cache_valid_time

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -15,6 +15,6 @@
   tags: cassandra
 
 - name: Install Cassandra packages
-  apt: name={{ item }} state=present update_cache=yes cache_valid_time=3600
+  apt: name={{ item }} state=present update_cache=yes
   with_items: cassandra_packages
   tags: cassandra


### PR DESCRIPTION
When trying to use install cassandra on an Ubuntu 12.04 image, I ran into the following error:

```
failed: [auth_service] => (item=libjna-java,cassandra=2.1.7) => {"failed": true, "item": "libjna-java,cassandra=2.1.7"}
stderr: E: There are problems and -y was used without --force-yes

stdout: Reading package lists...
Building dependency tree...
Reading state information...
The following packages were automatically installed and are no longer required:
  linux-headers-3.2.0-30 linux-headers-3.2.0-30-generic
Use 'apt-get autoremove' to remove them.
The following extra packages will be installed:
  python-support
Suggested packages:
  cassandra-tools libjna-java-doc
The following NEW packages will be installed:
  cassandra libjna-java python-support
0 upgraded, 3 newly installed, 0 to remove and 0 not upgraded.
Need to get 20.7 MB of archives.
After this operation, 23.7 MB of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  cassandra

msg: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'libjna-java' 'cassandra=2.1.7'' failed: E: There are problems and -y was used without --force-yes


FATAL: all hosts have already failed -- aborting
```

It appears that after installing the datastax repo key, an update is needed before the package can be installed. I simply removed the update cache check so it will now always run the update.

Tested locally with a vagrant and a very simple playbook that attempts to install cassandra 2.1.7.
